### PR TITLE
CoreWeave H100 Benchmark Setup

### DIFF
--- a/README-coreweave.md
+++ b/README-coreweave.md
@@ -1,6 +1,6 @@
 Running on Kubernetes
 ---------------------
-We provide a `Dockerfile` in `docs/Dockerfile.coreweave` that can be used to build your own container if required.
+We provide a `Dockerfile` in `docs/Dockerfile.coreweave` that can be used to build your own container if required. From `docs`, run `./build-coreweave-dockerfile.sh`.
 
 If you are set up on CoreWeave and have access to our H100s, you should be able to perform: `kubectl apply -f docs/optimum-habana-k8s.yaml`. If you need to run on a different GPU type, you can adjust the `H100_NVLINK_80GB` value to something else like `RTX_A6000`. Make sure to adjust the `BATCH_SZ` environment variable appropriately.
 

--- a/README-coreweave.md
+++ b/README-coreweave.md
@@ -1,0 +1,7 @@
+Running on Kubernetes
+---------------------
+We provide a `Dockerfile` in `docs/Dockerfile.coreweave` that can be used to build your own container if required.
+
+If you are set up on CoreWeave and have access to our H100s, you should be able to perform: `kubectl apply -f docs/optimum-habana-k8s.yaml`. If you need to run on a different GPU type, you can adjust the `H100_NVLINK_80GB` value to something else like `RTX_A6000`. Make sure to adjust the `BATCH_SZ` environment variable appropriately.
+
+Once running, you should be able to observe the output using `kubectl logs -f optimum-habana`. 

--- a/docs/Dockerfile.coreweave
+++ b/docs/Dockerfile.coreweave
@@ -2,7 +2,7 @@ FROM ghcr.io/coreweave/ml-containers/nightly-torch-extras:9faf4d7-nccl-2023.09.0
 ENV DEBIAN_FRONTEND=noninteractive
 
 #Install core packages
-RUN mkdir /src/optimum-habana
+RUN mkdir -p /src/optimum-habana
 COPY . /src/optimum-habana
 RUN apt-get update && apt-get install -y \
       curl git apt-utils ssh ca-certificates \
@@ -10,13 +10,19 @@ RUN apt-get update && apt-get install -y \
       ninja-build tini \
     && apt-get clean
 RUN pip3 install git+https://github.com/huggingface/transformers@6ae71ec \
-      datasets \
-      wandb
+      git+https://github.com/huggingface/accelerate@80da9cf \
+      datasets==2.14.5 \
+      wandb==0.15.1
+WORKDIR /usr/local/lib/python3.8/dist-packages/transformers
+RUN patch -p3 </src/optimum-habana/docs/transformers.patch
+WORKDIR /src
 RUN git clone https://github.com/NVIDIA/TransformerEngine.git && \
-      git checkout a29e2e1 && \
       cd TransformerEngine && \
+      git checkout a29e2e1 && \
       git submodule update --init --recursive && \
+      patch -p1 </src/optimum-habana/docs/te_layernorm.patch && \
+      python3 setup.py bdist_wheel || true && \
       chmod 755 .eggs/cmake-3.27.5-py3.8-linux-x86_64.egg/cmake/data/bin/cmake && \
-      pip3 build bdist_wheel && \
+      python3 setup.py bdist_wheel || true && \
       pip3 install dist/transformer_engine*.whl && \
       rm -rf TransformerEngine

--- a/docs/Dockerfile.coreweave
+++ b/docs/Dockerfile.coreweave
@@ -1,0 +1,22 @@
+FROM ghcr.io/coreweave/ml-containers/nightly-torch-extras:9faf4d7-nccl-2023.09.05.05-cuda12.1.1-nccl2.18.3-1-torch2.1.0a0-vision0.16.0a0-audio2.2.0a0-flash_attn2.0.2
+ENV DEBIAN_FRONTEND=noninteractive
+
+#Install core packages
+RUN mkdir /src/optimum-habana
+COPY . /src/optimum-habana
+RUN apt-get update && apt-get install -y \
+      curl git apt-utils ssh ca-certificates \
+      tmux nano vim sudo bash rsync htop wget unzip \
+      ninja-build tini \
+    && apt-get clean
+RUN pip3 install git+https://github.com/huggingface/transformers@6ae71ec \
+      datasets \
+      wandb
+RUN git clone https://github.com/NVIDIA/TransformerEngine.git && \
+      git checkout a29e2e1 && \
+      cd TransformerEngine && \
+      git submodule update --init --recursive && \
+      chmod 755 .eggs/cmake-3.27.5-py3.8-linux-x86_64.egg/cmake/data/bin/cmake && \
+      pip3 build bdist_wheel && \
+      pip3 install dist/transformer_engine*.whl && \
+      rm -rf TransformerEngine

--- a/docs/Dockerfile.coreweave
+++ b/docs/Dockerfile.coreweave
@@ -1,5 +1,8 @@
-FROM ghcr.io/coreweave/ml-containers/nightly-torch-extras:9faf4d7-nccl-2023.09.05.05-cuda12.1.1-nccl2.18.3-1-torch2.1.0a0-vision0.16.0a0-audio2.2.0a0-flash_attn2.0.2
+FROM ghcr.io/coreweave/ml-containers/nightly-torch-extras:29c37fa-nccl-2023.10.20.05-cuda12.2.2-nccl2.18.5-1-torch2.2.0a0-vision0.17.0a0-audio2.2.0a0-flash_attn1.0.9
 ENV DEBIAN_FRONTEND=noninteractive
+ARG TRANSFORMERS_VERSION=6ae71ec
+ARG ACCELERATE_VERSION=80da9cf
+ARG TE_VERSION=a29e2e1
 
 #Install core packages
 RUN mkdir -p /src/optimum-habana
@@ -9,8 +12,9 @@ RUN apt-get update && apt-get install -y \
       tmux nano vim sudo bash rsync htop wget unzip \
       ninja-build tini \
     && apt-get clean
-RUN pip3 install git+https://github.com/huggingface/transformers@6ae71ec \
-      git+https://github.com/huggingface/accelerate@80da9cf \
+RUN pip3 install --no-cache-dir \
+      git+https://github.com/huggingface/transformers@${TRANSFORMERS_VERSION} \
+      git+https://github.com/huggingface/accelerate@${ACCELERATE_VERSION} \
       datasets==2.14.5 \
       wandb==0.15.1
 WORKDIR /usr/local/lib/python3.8/dist-packages/transformers
@@ -18,11 +22,11 @@ RUN patch -p3 </src/optimum-habana/docs/transformers.patch
 WORKDIR /src
 RUN git clone https://github.com/NVIDIA/TransformerEngine.git && \
       cd TransformerEngine && \
-      git checkout a29e2e1 && \
+      git checkout ${TE_VERSION} && \
       git submodule update --init --recursive && \
       patch -p1 </src/optimum-habana/docs/te_layernorm.patch && \
       python3 setup.py bdist_wheel || true && \
-      chmod 755 .eggs/cmake-3.27.5-py3.8-linux-x86_64.egg/cmake/data/bin/cmake && \
-      python3 setup.py bdist_wheel || true && \
+      chmod 755 .eggs/cmake-*-py3.8-linux-x86_64.egg/cmake/data/bin/cmake && \
+      python3 setup.py bdist_wheel && \
       pip3 install dist/transformer_engine*.whl && \
       rm -rf TransformerEngine

--- a/docs/build-coreweave-dockerfile.sh
+++ b/docs/build-coreweave-dockerfile.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+TAG=$(echo "${GITHUB_SHA:-$(git rev-parse HEAD)}" | cut -c -7)
+cd .. && docker build . -t optimum-habana:${TAG} -f docs/Dockerfile.coreweave

--- a/docs/optimum-habana-k8s.yaml
+++ b/docs/optimum-habana-k8s.yaml
@@ -1,0 +1,70 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: optimum-habana
+spec:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: gpu.nvidia.com/class
+            operator: In
+            values:
+            - H100_NVLINK_80GB
+  containers:
+  - env:
+      - name: PYTHONBUFFERED
+        value: "1"
+
+      - name: NUM_GPUS
+        value: "8"
+
+      # 54 for 80GB GPUs
+      # 27 for 48GB GPUs
+      - name: BATCH_SZ
+        value: "54"
+
+      - name: SKIP_LOADER
+        value: "1"
+
+      # Uncomment the following, and insert your WandB key
+      # if you want run reporting.
+      #- name: WANDB_API_KEY
+      #  value: your_api_key
+
+      # Comment out the following if you uncomment above.
+      - name: WANDB_MODE
+        value: "offline"
+
+    command: ["/bin/bash"]
+    args: ["-c", "cd /src/optimum-habana/examples/contrastive-image-text && ./run.sh $NUM_GPUS $BATCH_SZ"]
+    image: wesbrown18/optimum-habana:rc0
+    imagePullPolicy: Always
+    name: optimum-habana-container
+    resources:
+      limits:
+        cpu: "48"
+        memory: 700Gi
+        nvidia.com/gpu: "8"
+        ephemeral-storage: 500Gi
+      requests:
+        cpu: "48"
+        memory: 700Gi
+        nvidia.com/gpu: "8"
+        ephemeral-storage: 500Gi
+    tty: true
+    volumeMounts:
+    - name: dshm
+      mountPath: /dev/shm
+  dnsPolicy: ClusterFirst
+  imagePullSecrets:
+  - name: regcred
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext: {}
+  terminationGracePeriodSeconds: 10
+  volumes:
+  - emptyDir:
+      medium: Memory
+    name: dshm

--- a/docs/optimum-habana-k8s.yaml
+++ b/docs/optimum-habana-k8s.yaml
@@ -39,7 +39,7 @@ spec:
 
     command: ["/bin/bash"]
     args: ["-c", "cd /src/optimum-habana/examples/contrastive-image-text && ./run.sh $NUM_GPUS $BATCH_SZ"]
-    image: wesbrown18/optimum-habana:rc0
+    image: wesbrown18/optimum-habana:rc7
     imagePullPolicy: Always
     name: optimum-habana-container
     resources:

--- a/docs/te_layernorm.patch
+++ b/docs/te_layernorm.patch
@@ -1,0 +1,13 @@
+diff --git a/transformer_engine/pytorch/module/layernorm.py b/transformer_engine/pytorch/module/layernorm.py
+index 41615af..b7ddfd8 100644
+--- a/transformer_engine/pytorch/module/layernorm.py
++++ b/transformer_engine/pytorch/module/layernorm.py
+@@ -41,7 +41,7 @@ class _LayerNorm(torch.autograd.Function):
+         in_features = ln_weight.numel()
+         assert inp.is_cuda, "TransformerEngine needs CUDA."
+         assert inp.shape[-1] == in_features, "LayerNorm not possible"
+-        inputmat = inp.view((-1, in_features))
++        inputmat = inp.reshape((-1, in_features))
+
+         # Cast for native AMP
+         inputmat = cast_if_needed(inputmat, activation_dtype)

--- a/docs/transformers.patch
+++ b/docs/transformers.patch
@@ -1,0 +1,153 @@
+diff --git a/src/transformers/models/bridgetower/modeling_bridgetower.py b/src/transformers/models/bridgetower/modeling_bridgetower.py
+index ce569157b..5877d3f16 100644
+--- a/src/transformers/models/bridgetower/modeling_bridgetower.py
++++ b/src/transformers/models/bridgetower/modeling_bridgetower.py
+@@ -23,6 +23,7 @@ import torch
+ import torch.utils.checkpoint
+ from torch import nn
+ from torch.nn import CrossEntropyLoss
++from transformer_engine import pytorch as te
+
+ from ...activations import ACT2FN, QuickGELUActivation
+ from ...modeling_outputs import (
+@@ -193,7 +194,7 @@ class BridgeTowerResidualAttention(nn.Module):
+         super().__init__()
+
+         self.attn = nn.MultiheadAttention(config.hidden_size, config.hidden_size // 64)
+-        self.ln_1 = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
++        self.ln_1 = te.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+         self.mlp = nn.ModuleDict(
+             OrderedDict(
+                 [
+@@ -203,7 +204,7 @@ class BridgeTowerResidualAttention(nn.Module):
+                 ]
+             )
+         )
+-        self.ln_2 = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
++        self.ln_2 = te.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+         self.attn_mask = None
+
+     def attention(self, hidden_state: torch.Tensor, attention_mask: torch.Tensor):
+@@ -299,13 +300,13 @@ class BridgeTowerVisionTransformer(nn.Module):
+         super().__init__()
+
+         self.embeddings = BridgeTowerVisionEmbeddings(config)
+-        self.ln_pre = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
++        self.ln_pre = te.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+         self.transformer = BridgeTowerTransformer(config)
+-        self.ln_post = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
++        self.ln_post = te.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+         self.share_layernorm = config.share_layernorm
+         if not config.share_layernorm:
+             self.ln_separate = nn.ModuleList(
+-                [nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps) for _ in range(config.num_hidden_layers)]
++                [te.LayerNorm(config.hidden_size, eps=config.layer_norm_eps) for _ in range(config.num_hidden_layers)]
+             )
+
+     def forward(self, pixel_values: torch.Tensor, attention_mask):
+@@ -353,7 +354,7 @@ class BridgeTowerLinkTower(nn.Module):
+                 self.scaled_factor = nn.Parameter(torch.tensor(1.0))
+             elif config.link_tower_type == "interpolate":
+                 self.beta = nn.Parameter(torch.tensor(0.5))
+-            self.LayerNorm = nn.LayerNorm(self.hidden_size, eps=config.layer_norm_eps)
++            self.LayerNorm = te.LayerNorm(self.hidden_size, eps=config.layer_norm_eps)
+         else:
+             raise NotImplementedError(f"link_tower_type {config.link_tower_type} is not implemented")
+
+@@ -373,7 +374,7 @@ class BridgeTowerSelfOutput(nn.Module):
+     def __init__(self, config):
+         super().__init__()
+         self.dense = nn.Linear(config.hidden_size, config.hidden_size)
+-        self.LayerNorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
++        self.LayerNorm = te.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+         self.dropout = nn.Dropout(config.hidden_dropout_prob)
+
+     def forward(self, hidden_states: torch.Tensor, input_tensor: torch.Tensor) -> torch.Tensor:
+@@ -404,7 +405,7 @@ class BridgeTowerOutput(nn.Module):
+     def __init__(self, config):
+         super().__init__()
+         self.dense = nn.Linear(config.intermediate_size, config.hidden_size)
+-        self.LayerNorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
++        self.LayerNorm = te.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+         self.dropout = nn.Dropout(config.hidden_dropout_prob)
+
+     def forward(self, hidden_states: torch.Tensor, input_tensor: torch.Tensor) -> torch.Tensor:
+@@ -877,7 +878,7 @@ class BridgeTowerTextEmbeddings(nn.Module):
+
+         # self.LayerNorm is not snake-cased to stick with TensorFlow model variable name and be able to load
+         # any TensorFlow checkpoint file
+-        self.LayerNorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
++        self.LayerNorm = te.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+         self.dropout = nn.Dropout(config.hidden_dropout_prob)
+         # position_ids (1, len position emb) is contiguous in memory and exported when serialized
+         self.position_embedding_type = getattr(config, "position_embedding_type", "absolute")
+@@ -1000,7 +1001,7 @@ class BridgeTowerPreTrainedModel(PreTrainedModel):
+             )
+         elif isinstance(module, (nn.Linear, nn.Conv2d, nn.Embedding)):
+             module.weight.data.normal_(mean=0.0, std=0.05 * self.config.initializer_factor)
+-        elif isinstance(module, nn.LayerNorm):
++        elif isinstance(module, te.LayerNorm):
+             module.bias.data.zero_()
+             module.weight.data.fill_(1.0)
+
+@@ -1245,8 +1246,8 @@ class BridgeTowerModel(BridgeTowerPreTrainedModel):
+         self.cross_modal_text_pooler = BridgeTowerPooler(config)
+
+         # Initialize BridgeTower Components
+-        self.cross_modal_text_layernorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+-        self.cross_modal_image_layernorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
++        self.cross_modal_text_layernorm = te.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
++        self.cross_modal_image_layernorm = te.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+
+         if config.share_link_tower_layers:
+             self.cross_modal_text_link_tower = BridgeTowerLinkTower(config)
+@@ -1508,7 +1509,7 @@ class BridgeTowerPredictionHeadTransform(nn.Module):
+             self.transform_act_fn = ACT2FN[config.hidden_act]
+         else:
+             self.transform_act_fn = config.hidden_act
+-        self.LayerNorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
++        self.LayerNorm = te.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+
+     def forward(self, hidden_states):
+         hidden_states = self.dense(hidden_states)
+diff --git a/src/transformers/trainer.py b/src/transformers/trainer.py
+index b9e103761..ea79cd446 100755
+--- a/src/transformers/trainer.py
++++ b/src/transformers/trainer.py
+@@ -1139,8 +1139,6 @@ class Trainer:
+             optimizer_cls = torch.optim.SGD
+         elif args.optim == OptimizerNames.ADAGRAD:
+             optimizer_cls = torch.optim.Adagrad
+-        elif args.optim == OptimizerNames.RMSPROP:
+-            optimizer_cls = torch.optim.RMSprop
+         else:
+             raise ValueError(f"Trainer cannot instantiate unsupported optimizer: {args.optim}")
+         return optimizer_cls, optimizer_kwargs
+@@ -1840,6 +1838,11 @@ class Trainer:
+                     sampler = sampler if sampler is not None else []
+                     _ = list(sampler)
+
++        # get a batch of data
++        for step, inputs in enumerate(train_dataloader):
++            saved_inputs = inputs
++            break
++
+         total_batched_samples = 0
+         for epoch in range(epochs_trained, num_train_epochs):
+             epoch_iterator = train_dataloader
+@@ -1867,7 +1870,14 @@ class Trainer:
+                 rng_to_sync = True
+
+             step = -1
+-            for step, inputs in enumerate(epoch_iterator):
++            skip_loader = os.getenv("SKIP_LOADER") == '1'
++            # only use one batch of data when skip loader
++            if skip_loader:
++                epoch_iterator_override = [saved_inputs for i in range(len(epoch_iterator))]
++            else:
++                epoch_iterator_override = epoch_iterator
++
++            for step, inputs in enumerate(epoch_iterator_override):
+                 total_batched_samples += 1
+                 if rng_to_sync:
+                     self._load_rng_state(resume_from_checkpoint)

--- a/examples/contrastive-image-text/run.sh
+++ b/examples/contrastive-image-text/run.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+torchrun --nproc-per-node $1 \
+        run_bridgetower.py \
+	--per_device_train_batch_size=$2 \
+	--output_dir /tmp/bridgetower_test \
+	--model_name_or_path BridgeTower/bridgetower-large-itm-mlm-itc \
+	--dataset_name jmhessel/newyorker_caption_contest \
+	--dataset_config_name matching \
+	--image_column image \
+        --caption_column image_description \
+	--remove_unused_columns=False \
+	--do_train \
+        --fp16 \
+	--fp16_opt_level=O2 \
+	--half_precision_backend=apex \
+	--optim="adamw_apex_fused" \
+	--num_train_epochs 5 \
+	--learning_rate="1e-5" \
+	--overwrite_output_dir \
+	--logging_steps 10 \
+	--save_steps 5000 \
+	--dataloader_num_workers=2


### PR DESCRIPTION
Running on Kubernetes
---------------------
If you are set up on CoreWeave and have access to our H100s, you should be able to perform: `kubectl apply -f docs/optimum-habana-k8s.yaml`. If you need to run on a different GPU type, you can adjust the `H100_NVLINK_80GB` value to something else like `RTX_A6000`. Make sure to adjust the `BATCH_SZ` environment variable appropriately.

Once running, you should be able to observe the output using `kubectl logs -f optimum-habana`.

Building your own Docker image
----------------------
We provide a `Dockerfile` in `docs/Dockerfile.coreweave` that can be used to build your own container if required.

This will use our optimized Torch images as a foundation, set up the source code, and pull down the necessary latest versions of:
* `accelerate`
* `transformers`  (patched with `docs/transformers.patch`)
* `TransformerEngine` (patched with `docs/te_layernorm.patch`)

In a Kubernetes environment (typically CoreWeave), you can apply the `docs/optimum-hash-k8s.yaml` pod spec. Documented in the specs are settings you can tweak such as `NUM_GPUS`, `BATCH_SZ`.